### PR TITLE
feature(TSK-006): zustand game events

### DIFF
--- a/src/components/GameEvents/GameEvent.tsx
+++ b/src/components/GameEvents/GameEvent.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import { TGameEvent } from '@/features/game/typings';
+
+interface IOwnProps {
+  event: TGameEvent;
+}
+
+export const GameEvent = ( props: IOwnProps ) => {
+  const { event } = props;
+
+  return <li style={{ marginBottom: "0.5rem" }}>
+    {event.type}- Game ID: {event.gameId}
+  </li>
+}

--- a/src/components/GameEvents/GameEvents.tsx
+++ b/src/components/GameEvents/GameEvents.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { useGameEvents } from "@/hooks/useGameEvents"
+import { GameEvent } from './GameEvent'
 
 export const GameEvents = () => {
   const gameEvents = useGameEvents()
@@ -18,12 +19,11 @@ export const GameEvents = () => {
       <p>No events yet</p>
     ) : (
       <ul>
-        {gameEvents.map((event, index) => (
-          <li key={index} style={{ marginBottom: "0.5rem" }}>
-            {event.type}- Game ID: {event.gameId}
-          </li>
-        ))}
+        {gameEvents.map((event) => <GameEvent
+          key={`${event.gameId}-${event.timestamp}`} 
+          event={event}
+        />)}
       </ul>
     )}
   </div>
-}
+} 

--- a/src/components/GameEvents/GameEvents.tsx
+++ b/src/components/GameEvents/GameEvents.tsx
@@ -20,7 +20,7 @@ export const GameEvents = () => {
     ) : (
       <ul>
         {gameEvents.map((event) => <GameEvent
-          key={`${event.gameId}-${event.timestamp}`} 
+          key={`${event.gameId}-${event.timestamp}-${Math.random().toString(36).substring(2, 15)}`} 
           event={event}
         />)}
       </ul>

--- a/src/features/game/gameStore.ts
+++ b/src/features/game/gameStore.ts
@@ -1,18 +1,67 @@
 import create from "zustand";
 import { TGameEvent, IGame } from "@/features/game/typings";
+import { mockSocket } from "@/services/socket";
 
 interface GameState {
   games: IGame[];
   events: TGameEvent[];
+  socketConnected: boolean;
   setGames: (games: IGame[]) => void;
   addEvent: (event: TGameEvent) => void;
   resetEvents: () => void;
+  /**
+   * Establishes a WebSocket connection to receive real-time game events.
+   * If already connected or if there are no games, it does nothing.
+   * On receiving a game event, it adds the event to the state using the addEvent method.
+   * @returns void
+   */
+  connectSocket: () => void;
+  /**
+   *  Disconnects from the WebSocket and cleans up any listeners to prevent memory leaks.
+   *  If not connected, it does nothing.
+   * @returns void
+   */
+  disconnectSocket: () => void;
 }
 
-export const useGameStore = create<GameState>((set) => ({
+/**
+ * Zustand store for managing game state and real-time game events.
+ * It includes methods to set games, add events, reset events,
+ * and manage WebSocket connections for receiving game events. 
+ */
+export const useGameStore = create<GameState>((set, get) => ({
   games: [],
   events: [],
+  socketConnected: false,
   setGames: (games) => set({ games }),
-  addEvent: (event) => set((state) => ({ events: [event, ...state.events] })),
+  addEvent: (event) => set((state) => {
+    const updated = [event, ...state.events];
+    return { events: updated.slice(0, 20) }; // ✅ limit to 20 as not to grow indefinitely
+  }),
   resetEvents: () => set({ events: [] }),
+  
+  connectSocket: () => {
+    const { socketConnected, games, addEvent } = get();
+    if (socketConnected || games.length === 0) return;
+
+    const handleMessage = (event: TGameEvent) => {
+      addEvent(event);
+    };
+
+    mockSocket.connect(games);
+    mockSocket.onMessage(handleMessage);
+
+    (mockSocket as any)._zustandHandler = handleMessage;
+    set({ socketConnected: true });
+  },
+
+  disconnectSocket: () => {
+    const handler = (mockSocket as any)._zustandHandler;
+    if (handler) {
+      mockSocket.removeListener(handler);
+      delete (mockSocket as any)._zustandHandler;
+    }
+    mockSocket.disconnect();
+    set({ socketConnected: false });
+  },
 }));

--- a/src/features/game/gameStore.ts
+++ b/src/features/game/gameStore.ts
@@ -1,0 +1,18 @@
+import create from "zustand";
+import { TGameEvent, IGame } from "@/features/game/typings";
+
+interface GameState {
+  games: IGame[];
+  events: TGameEvent[];
+  setGames: (games: IGame[]) => void;
+  addEvent: (event: TGameEvent) => void;
+  resetEvents: () => void;
+}
+
+export const useGameStore = create<GameState>((set) => ({
+  games: [],
+  events: [],
+  setGames: (games) => set({ games }),
+  addEvent: (event) => set((state) => ({ events: [event, ...state.events] })),
+  resetEvents: () => set({ events: [] }),
+}));

--- a/src/features/game/typings.ts
+++ b/src/features/game/typings.ts
@@ -17,6 +17,9 @@ export interface IGame {
     description: string,
     slug: string,
     category: string,
+    collections: string[],
+    isNew: boolean,
+    isLiveGame: boolean,
   }
   media: {
     thumbnail: {

--- a/src/hooks/useGameEvents.ts
+++ b/src/hooks/useGameEvents.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { useSelector } from "react-redux";
 
 import { selectFilteredGames } from "@/features/lobby/selectors";
@@ -16,19 +16,20 @@ import { useGameStore } from "@/features/game/gameStore";
 export function useGameEvents() {
     const games = useSelector(selectFilteredGames);
     const events = useGameStore((state) => state.events);
-    const setGames = useGameStore((s) => s.setGames);
     const connectSocket = useGameStore((s) => s.connectSocket);
     const disconnectSocket = useGameStore((s) => s.disconnectSocket);
-
+    const didConnect = useRef(false);
     useEffect(() => {
         if (games.length === 0) return;
 
-        setGames(games);
-        connectSocket();
+        if (!didConnect.current) {
+            connectSocket(games);
+            didConnect.current = true;
+        }
         return () => {
             disconnectSocket();
         };
-    }, [games, setGames, connectSocket, disconnectSocket]);
+    }, [games, connectSocket, disconnectSocket]);
 
     return events
 }

--- a/src/hooks/useGameEvents.ts
+++ b/src/hooks/useGameEvents.ts
@@ -1,28 +1,26 @@
 import { useEffect, useState } from "react"
+import { useSelector } from "react-redux";
+
 import { mockSocket } from "../services/socket"
 import { TGameEvent } from "@/features/game/typings"
-
-
-// The games are hardcoded for now, but should be fetched from the API
-const mockGames = [
-    { id: "1", gameText: "Game 1" },
-    { id: "2", gameText: "Game 2" },
-    { id: "3", gameText: "Game 3" },
-]
+import { selectFilteredGames } from "@/features/lobby/selectors";
+import { useGameStore } from "@/features/game/gameStore";
 
 export function useGameEvents() {
-    const [events, setEvents] = useState<TGameEvent[]>([])
+    const games = useSelector(selectFilteredGames);
+    const addEvent = useGameStore((state) => state.addEvent);
+    const events = useGameStore((state) => state.events);
 
     useEffect(() => {
-        if (mockGames.length === 0) {
+        if (games.length === 0) {
             return
         }
 
         const handleMessage = (event: TGameEvent) => {
-            setEvents((prev) => [event, ...prev])
+            addEvent(event);
         }
 
-        mockSocket.connect(mockGames)
+        mockSocket.connect(games)
         mockSocket.onMessage(handleMessage)
 
         return () => {
@@ -32,7 +30,7 @@ export function useGameEvents() {
                 mockSocket.disconnect()
             }
         }
-    }, [])
+    }, [games, addEvent]);
 
     return events
 }

--- a/src/hooks/useGameEvents.ts
+++ b/src/hooks/useGameEvents.ts
@@ -1,36 +1,34 @@
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { useSelector } from "react-redux";
 
-import { mockSocket } from "../services/socket"
-import { TGameEvent } from "@/features/game/typings"
 import { selectFilteredGames } from "@/features/lobby/selectors";
 import { useGameStore } from "@/features/game/gameStore";
 
+/**
+ * This hook connects to a mock WebSocket service to receive real-time game events.
+ * It uses Zustand for state management and React-Redux to select filtered games from the Redux store.
+ * When the component using this hook mounts, it sets the current filtered games in the Zustand store
+ * and establishes a WebSocket connection to receive game events.
+ * On unmount, it disconnects from the WebSocket to prevent memory leaks.
+ * 
+ * @returns An array of game events from the Zustand store.
+ */
 export function useGameEvents() {
     const games = useSelector(selectFilteredGames);
-    const addEvent = useGameStore((state) => state.addEvent);
     const events = useGameStore((state) => state.events);
+    const setGames = useGameStore((s) => s.setGames);
+    const connectSocket = useGameStore((s) => s.connectSocket);
+    const disconnectSocket = useGameStore((s) => s.disconnectSocket);
 
     useEffect(() => {
-        if (games.length === 0) {
-            return
-        }
+        if (games.length === 0) return;
 
-        const handleMessage = (event: TGameEvent) => {
-            addEvent(event);
-        }
-
-        mockSocket.connect(games)
-        mockSocket.onMessage(handleMessage)
-
+        setGames(games);
+        connectSocket();
         return () => {
-            mockSocket.removeListener(handleMessage)
-
-            if (mockSocket['listeners'].length === 0) {
-                mockSocket.disconnect()
-            }
-        }
-    }, [games, addEvent]);
+            disconnectSocket();
+        };
+    }, [games, setGames, connectSocket, disconnectSocket]);
 
     return events
 }

--- a/src/services/socket.ts
+++ b/src/services/socket.ts
@@ -1,5 +1,5 @@
 import { NEW_GAME, POPULARITY_UPDATE } from "@/features/game/constants"
-import { TGameEvent } from "@/features/game/typings"
+import { IGame, TGameEvent } from "@/features/game/typings"
 
 /**
  * A mock WebSocket that simulates receiving game events every 15 seconds.
@@ -10,15 +10,36 @@ class MockSocket {
     private listeners: ((event: TGameEvent) => void)[] = []
     /** Asserts that interval is set once */
     private isConnected = false
+    games: { id: string} [] | undefined
 
     connect(games: { id: string }[]) {
         if (!games.length || this.isConnected) {
             return
         }
 
+        this.games = games
+
         this.isConnected = true
+        if ( this.games.length > 0) {
+            // Emit 5 events immediately on connection as if there was some backlog
+            for (let i = 0; i < 5; i++) {
+                const game = this.games[Math.floor(Math.random() * this.games.length)]
+                const type: TGameEvent["type"] = Math.random() > 0.5 ? NEW_GAME : POPULARITY_UPDATE
+                const event: TGameEvent = { type, gameId: game.id, timestamp: Date.now() }
+                this.listeners.forEach(cb => cb(event))
+            }
+        };
+        this.startPulling()
+    }
+
+    updateGames(games: IGame[]) {
+        this.games = games
+    }
+
+    private startPulling() {
         this.interval = setInterval(() => {
-            const game = games[Math.floor(Math.random() * games.length)]
+            if ( this.games === undefined || this.games.length === 0) return;
+            const game = this.games[Math.floor(Math.random() * this.games.length)]
             const type: TGameEvent["type"] = Math.random() > 0.5 ? NEW_GAME : POPULARITY_UPDATE
 
             const event: TGameEvent = { type, gameId: game.id, timestamp: Date.now() }

--- a/src/services/socket.ts
+++ b/src/services/socket.ts
@@ -8,6 +8,7 @@ import { TGameEvent } from "@/features/game/typings"
 class MockSocket {
     private interval?: NodeJS.Timeout
     private listeners: ((event: TGameEvent) => void)[] = []
+    /** Asserts that interval is set once */
     private isConnected = false
 
     connect(games: { id: string }[]) {
@@ -22,7 +23,7 @@ class MockSocket {
 
             const event: TGameEvent = { type, gameId: game.id, timestamp: Date.now() }
             this.listeners.forEach(cb => cb(event))
-        }, 15000)
+        }, 10000)
     }
 
     onMessage(callback: (event: TGameEvent) => void) {


### PR DESCRIPTION
#### Change Log
-  game events are now using actual list of game ids
-  zustand is used to handle mock socket store as a global store connection with socket.io "mocked"
- mock socket io object does retrieve backlog items upon connected
- socket instance is atomic and initialized once per life time, and allows for multiple subscribed hooks.
- hook added to integrate react with mock socket by the help of zustand
- react code is now independent from mock socket service

#### Features updated
-  mock socket

#### Visual changes(.jpg, .gif, .mp4):
