### PR TITLE
bugfix(TSK-011): slim data sets

### DIFF
--- a/src/features/game/gamesApi.ts
+++ b/src/features/game/gamesApi.ts
@@ -30,7 +30,26 @@ export async function fetchAPIGames(pageSize = 100, search = ''): Promise<IGame[
   }
 
   const data = await response.json();
-  return data.items || [];
+  // Slim game objects to IGame only
+  const slimGames: IGame[] = (data.items || []).map((item: any) => ({
+    id: item.id,
+    meta: {
+      name: item.meta?.name || "",
+      title: item.meta?.title || "",
+      description: item.meta?.description || "",
+      category: item.meta?.category || "",
+      collections: item.meta?.collections || [],
+    },
+    media: {
+      thumbnail: {
+        thumbnail: {
+          src: item.media?.thumbnail?.thumbnail?.src || "",
+        },
+      },
+    },
+  }));
+
+  return slimGames;
 }
 
 /**

--- a/src/features/game/typings.ts
+++ b/src/features/game/typings.ts
@@ -15,11 +15,8 @@ export interface IGame {
     name: string,
     title: string,
     description: string,
-    slug: string,
     category: string,
     collections: string[],
-    isNew: boolean,
-    isLiveGame: boolean,
   }
   media: {
     thumbnail: {

--- a/src/features/lobby/configApi.ts
+++ b/src/features/lobby/configApi.ts
@@ -15,7 +15,19 @@ export async function fetchCategories(): Promise<IItems[]> {
   }
 
   const data = await response.json();
-  const lobbyCategories: IItems[] = data.menu?.lobby?.items || [];
+  const rawItems: IItems[] = data.menu?.lobby?.items || [];
+  
+  // slim version, mapped to IItems only as to reduce hydration on client side
+  // we don't need all the data from the config for categories
+  const lobbyCategories: IItems[] = rawItems.map((item: any) => ({
+    id: item.id,
+    image: {
+      alt: item.image?.alt || "", // only alt, not the whole image object
+    },
+    name: item.name || {},
+    type: item.type || "",
+    categoryFilter: item.categoryFilter || undefined,
+  }));
   return lobbyCategories;
 }
 

--- a/src/features/lobby/typings.ts
+++ b/src/features/lobby/typings.ts
@@ -14,11 +14,6 @@ export interface IItems {
    * { "en": "Popular", "fi": "Pelatuimmat" } */
   name: Record<string, string>
   /**
-   * Localized paths
-   * @example
-   * { "en": "/casino/most-popular", "fi": null } */
-  paths: Record<string, string | null>
-  /**
    * Type of filter, e.g. "categoryFilter", "liveCategoryRows"
    */
   type: string


### PR DESCRIPTION
#### Change Log
-  mappers for data sets as to reduce hydration issues on redux store state 

#### Features updated
-  redux

#### Visual changes(.jpg, .gif, .mp4):

before: warning was showing
<img width="866" height="162" alt="massive data set" src="https://github.com/user-attachments/assets/e160b149-89ca-472f-aafc-3f024fc5d7e8" />

after: ok
<img width="583" height="562" alt="slim data set" src="https://github.com/user-attachments/assets/bb6c7ba1-ba40-4a2d-9614-26ce32350f2f" />

